### PR TITLE
Task 7 Authorizer function

### DIFF
--- a/authorization-service/handler.ts
+++ b/authorization-service/handler.ts
@@ -1,0 +1,3 @@
+import { basicAuthorizer } from './src/handlers/basicAuthorizer';
+
+export { basicAuthorizer };

--- a/authorization-service/package.json
+++ b/authorization-service/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "authorization-service",
+  "version": "1.0.0",
+  "description": "Serverless webpack example using Typescript",
+  "main": "handler.js",
+  "scripts": {
+    "deploy": "sls deploy"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@serverless/typescript": "^2.12.0",
+    "@types/aws-lambda": "^8.10.64",
+    "@types/node": "^14.14.6",
+    "serverless": "^2.13.0",
+    "serverless-dotenv-plugin": "^3.1.0",
+    "serverless-webpack": "^5.2.0",
+    "ts-loader": "^8.0.10",
+    "ts-node": "^9.0.0",
+    "typescript": "^4.0.5",
+    "webpack": "^5.4.0",
+    "webpack-node-externals": "^2.5.2"
+  },
+  "author": "The serverless webpack authors (https://github.com/elastic-coders/serverless-webpack)",
+  "license": "MIT"
+}

--- a/authorization-service/serverless.ts
+++ b/authorization-service/serverless.ts
@@ -1,0 +1,45 @@
+import type { AWS } from '@serverless/typescript';
+
+const serverlessConfiguration: AWS = {
+  service: 'authorization-service',
+  frameworkVersion: '2',
+  custom: {
+    webpack: {
+      webpackConfig: './webpack.config.js',
+      includeModules: true,
+    },
+  },
+  plugins: ['serverless-webpack', 'serverless-dotenv-plugin'],
+  provider: {
+    name: 'aws',
+    runtime: 'nodejs12.x',
+    stage: 'dev',
+    region: 'eu-west-1',
+    apiGateway: {
+      minimumCompressionSize: 1024,
+      shouldStartNameWithService: true,
+    },
+    environment: {
+      AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+    },
+  },
+  functions: {
+    basicAuthorizer: {
+      handler: 'handler.basicAuthorizer',
+    },
+  },
+  resources: {
+    Outputs: {
+      BasicAuthorizerArn: {
+        Value: {
+          'Fn::GetAtt': ['BasicAuthorizerLambdaFunction', 'Arn'],
+        },
+        Export: {
+          Name: 'BasicAuthorizerArn',
+        },
+      },
+    },
+  },
+};
+
+module.exports = serverlessConfiguration;

--- a/authorization-service/src/constants/index.ts
+++ b/authorization-service/src/constants/index.ts
@@ -1,0 +1,4 @@
+export const HEADERS: { [header: string]: boolean | number | string; } = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Credentials': true,
+};

--- a/authorization-service/src/handlers/basicAuthorizer.ts
+++ b/authorization-service/src/handlers/basicAuthorizer.ts
@@ -1,0 +1,38 @@
+import { inspect } from 'util';
+import { APIGatewayAuthorizerHandler } from 'aws-lambda/trigger/api-gateway-authorizer';
+import { generatePolicy } from '../utils/generatePolicy';
+
+export const basicAuthorizer: APIGatewayAuthorizerHandler = (event, _context, callback) => {
+  console.log('Start invoking basicAuthorizer function', inspect(event, { depth: 5 }));
+  try {
+    if (event.type !== 'REQUEST') {
+      callback('Unauthorized');
+      return; // need this explicit return to avoid typescript errors
+    }
+
+    const authHeader = event.headers.Authorization;
+    if (!authHeader || authHeader.split(' ')[0] !== 'Basic') {
+      callback('Unauthorized');
+      return;
+    }
+
+    const encodedCreds = authHeader.split(' ')[1];
+    if (!encodedCreds) {
+      callback('Unauthorized');
+      return;
+    }
+    const buffer = Buffer.from(encodedCreds, 'base64');
+    const plainCreds = buffer.toString('utf-8').split(':');
+    const [name, password] = plainCreds;
+
+    console.log(`Username: ${name}, password: ${password}`);
+
+    const storedPassword = process.env[name];
+    const effect = !storedPassword || storedPassword !== password ? 'Deny' : 'Allow';
+    const policy = generatePolicy(encodedCreds, event.methodArn, effect);
+    callback(null, policy);
+  } catch (e) {
+    console.error(e);
+    callback('Authorizer failure');
+  }
+};

--- a/authorization-service/src/utils/createResponse.ts
+++ b/authorization-service/src/utils/createResponse.ts
@@ -1,0 +1,16 @@
+import { HEADERS } from '../constants';
+import { APIGatewayProxyResult } from 'aws-lambda';
+
+const createResponse = (
+  statusCode: number,
+  body: { [key: string]: any } | string,
+  headers?: { [header: string]: boolean | number | string; }
+): APIGatewayProxyResult => {
+  return {
+    statusCode,
+    headers: { ...HEADERS, ...headers },
+    body: typeof body === 'string' ? body : JSON.stringify(body, null, 2),
+  };
+};
+
+export default createResponse;

--- a/authorization-service/src/utils/generatePolicy.ts
+++ b/authorization-service/src/utils/generatePolicy.ts
@@ -1,0 +1,17 @@
+import { APIGatewayAuthorizerResult } from 'aws-lambda';
+
+export const generatePolicy = (principalId: string, resource: string, effect: string): APIGatewayAuthorizerResult => {
+  return {
+    principalId,
+    policyDocument: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Action: 'execute-api:Invoke',
+          Effect: effect,
+          Resource: resource,
+        },
+      ],
+    },
+  };
+};

--- a/authorization-service/tsconfig.json
+++ b/authorization-service/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "lib": ["es2017"],
+    "removeComments": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "sourceMap": true,
+    "target": "es2017",
+    "outDir": "lib"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": [
+    "node_modules/**/*",
+    ".serverless/**/*",
+    ".webpack/**/*",
+    "_warmup/**/*",
+    ".vscode/**/*"
+  ]
+}

--- a/authorization-service/webpack.config.js
+++ b/authorization-service/webpack.config.js
@@ -1,0 +1,46 @@
+const path = require('path');
+const slsw = require('serverless-webpack');
+const nodeExternals = require('webpack-node-externals');
+
+module.exports = {
+  context: __dirname,
+  mode: slsw.lib.webpack.isLocal ? 'development' : 'production',
+  entry: slsw.lib.entries,
+  devtool: slsw.lib.webpack.isLocal ? 'eval-cheap-module-source-map' : 'source-map',
+  resolve: {
+    extensions: ['.mjs', '.json', '.ts'],
+    symlinks: false,
+    cacheWithContext: false,
+  },
+  output: {
+    libraryTarget: 'commonjs',
+    path: path.join(__dirname, '.webpack'),
+    filename: '[name].js',
+  },
+  optimization: {
+    concatenateModules: false,
+  },
+  target: 'node',
+  externals: [nodeExternals()],
+  module: {
+    rules: [
+      {
+        test: /\.(tsx?)$/,
+        loader: 'ts-loader',
+        exclude: [
+          [
+            path.resolve(__dirname, 'node_modules'),
+            path.resolve(__dirname, '.serverless'),
+            path.resolve(__dirname, '.webpack'),
+          ],
+        ],
+        options: {
+          transpileOnly: true,
+          experimentalWatchApi: true,
+        },
+      },
+    ],
+  },
+  plugins: [
+  ],
+};

--- a/import-service/src/utils/apiGatewayResponse.ts
+++ b/import-service/src/utils/apiGatewayResponse.ts
@@ -1,0 +1,29 @@
+interface APIGatewayResponse {
+  Type: string;
+  Properties: {
+    RestApiId: string | { [key: string]: string };
+    ResponseType: string;
+    ResponseParameters: { [key: string]: string };
+    ResponseTemplates?: { [key: string]: string };
+  }
+}
+
+export const apiGatewayResponse = (type: string, template?: string): APIGatewayResponse => {
+  const response: APIGatewayResponse = {
+    Type: 'AWS::ApiGateway::GatewayResponse',
+    Properties: {
+      RestApiId: { Ref: 'ApiGatewayRestApi' },
+      ResponseType: type,
+      ResponseParameters: {
+        'gatewayresponse.header.Access-Control-Allow-Origin': "'*'",
+        'gatewayresponse.header.Access-Control-Allow-Headers': "'*'",
+      },
+    },
+  };
+  if (template) {
+    response.Properties.ResponseTemplates = {
+      'application/json': template
+    };
+  }
+  return response;
+}


### PR DESCRIPTION
Basic tasks:
- [x] Task 7.1 basicAuthorizer lambda created;
- [x] Task 7.2 basicAuthorizer lambda integrated with import service;
- [x] Task 7.3 token added to localStorage;

Additional tasks:
- [x] client shows alert on 401 and 403 error;

Import endpoint:
https://ctgkhw46g9.execute-api.eu-west-1.amazonaws.com/dev/import

FE PR:
https://github.com/AndreyS55/nodejs-aws-fe/pull/8

App URL:
https://d1na521rkvd94d.cloudfront.net/

localStorage has `authorization_token` field with encoded credentials. To check 403 error you could delete something from encoded string. To check 401 error you could remove encoded string, but keep field name.

Correct token : `QW5kcmV5UzU1OlRFU1RfUEFTU1dPUkQ=`
Correct header: `Authorization: Basic QW5kcmV5UzU1OlRFU1RfUEFTU1dPUkQ=`